### PR TITLE
Small optimisations for IPA verification

### DIFF
--- a/plonkish_backend/src/pcs/multilinear/ipa.rs
+++ b/plonkish_backend/src/pcs/multilinear/ipa.rs
@@ -295,10 +295,9 @@ where
             xi_invs.iter_mut().batch_invert();
             xi_invs
         };
-        let h = MultilinearPolynomial::new(h_coeffs(&xis));
-        let hc = h.evals().iter().map(|h| *h * neg_c).collect_vec();
-        let u = &(xi_0 * (neg_c * h.evaluate(point) + eval));
-        let scalars = chain![&xi_invs, &xis, &hc, Some(u)];
+        let neg_c_h = MultilinearPolynomial::new(h_coeffs(neg_c, &xis));
+        let u = &(xi_0 * (neg_c_h.evaluate(point) + eval));
+        let scalars = chain![&xi_invs, &xis, neg_c_h.evals(), Some(u)];
         let bases = chain![&ls, &rs, vp.g(), Some(vp.h())];
         bool::from((variable_base_msm(scalars, bases) + comm.0).is_identity())
             .then_some(())
@@ -317,11 +316,11 @@ where
     }
 }
 
-fn h_coeffs<F: Field>(xi: &[F]) -> Vec<F> {
+fn h_coeffs<F: Field>(scalar: F, xi: &[F]) -> Vec<F> {
     assert!(!xi.is_empty());
 
     let mut coeffs = vec![F::ZERO; 1 << xi.len()];
-    coeffs[0] = F::ONE;
+    coeffs[0] = scalar;
 
     for (len, xi) in xi.iter().rev().enumerate().map(|(i, xi)| (1 << i, xi)) {
         let (left, right) = coeffs.split_at_mut(len);


### PR DESCRIPTION
According to [BGH19](https://eprint.iacr.org/2019/1021.pdf) section 3.1 verifier can compute `G_0_prime` (it was `g_k` in the code) so we don't have to write it to the proof and compare it in verifier time