### PR TITLE
A fix for a verification error caused by different chunk_size in pre-processing and proving

### DIFF
--- a/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
+++ b/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
@@ -458,7 +458,7 @@ where
         ]
         .collect_vec();
         let permutation_z_polys = permutation_z_polys::<_, BinaryField>(
-            pp.max_degree -1,
+            pp.max_degree - 1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,

--- a/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
+++ b/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
@@ -458,6 +458,7 @@ where
         ]
         .collect_vec();
         let permutation_z_polys = permutation_z_polys::<_, BinaryField>(
+            pp.max_degree -1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,

--- a/plonkish_backend/src/backend/hyperplonk.rs
+++ b/plonkish_backend/src/backend/hyperplonk.rs
@@ -44,6 +44,7 @@ where
     F: PrimeField,
     Pcs: PolynomialCommitmentScheme<F>,
 {
+    pub(crate) max_degree: usize,
     pub(crate) pcs: Pcs::ProverParam,
     pub(crate) num_instances: Vec<usize>,
     pub(crate) num_witness_polys: Vec<usize>,
@@ -178,6 +179,7 @@ where
 
         let timer = start_timer(|| format!("permutation_z_polys-{}", pp.permutation_polys.len()));
         let permutation_z_polys = permutation_z_polys::<_, BinaryField>(
+            pp.max_degree -1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,

--- a/plonkish_backend/src/backend/hyperplonk.rs
+++ b/plonkish_backend/src/backend/hyperplonk.rs
@@ -179,7 +179,7 @@ where
 
         let timer = start_timer(|| format!("permutation_z_polys-{}", pp.permutation_polys.len()));
         let permutation_z_polys = permutation_z_polys::<_, BinaryField>(
-            pp.max_degree -1,
+            pp.max_degree - 1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,

--- a/plonkish_backend/src/backend/hyperplonk/prover.rs
+++ b/plonkish_backend/src/backend/hyperplonk/prover.rs
@@ -249,6 +249,7 @@ pub(super) fn lookup_h_poly<F: PrimeField + Hash>(
 }
 
 pub(crate) fn permutation_z_polys<F: PrimeField, R: Rotatable + From<usize>>(
+    chunk_size: usize,
     num_chunks: usize,
     permutation_polys: &[(usize, MultilinearPolynomial<F>)],
     polys: &[impl Borrow<MultilinearPolynomial<F>>],
@@ -259,7 +260,6 @@ pub(crate) fn permutation_z_polys<F: PrimeField, R: Rotatable + From<usize>>(
         return Vec::new();
     }
 
-    let chunk_size = div_ceil(permutation_polys.len(), num_chunks);
     let polys = polys.iter().map(Borrow::borrow).collect_vec();
     let num_vars = polys[0].num_vars();
 

--- a/plonkish_backend/src/backend/hyperplonk/util.rs
+++ b/plonkish_backend/src/backend/hyperplonk/util.rs
@@ -56,7 +56,7 @@ pub fn vanilla_plonk_expression<F: PrimeField>(num_vars: usize) -> Expression<F>
         Default::default(),
         vec![vec![(6, 1)], vec![(7, 1)], vec![(8, 1)]],
     );
-    let (num_permutation_z_polys, expression) = compose(&circuit_info);
+    let (num_permutation_z_polys, expression, _) = compose(&circuit_info);
     assert_eq!(num_permutation_z_polys, 1);
     expression
 }
@@ -93,7 +93,7 @@ pub fn vanilla_plonk_w_lookup_expression<F: PrimeField>(num_vars: usize) -> Expr
         Default::default(),
         vec![vec![(10, 1)], vec![(11, 1)], vec![(12, 1)]],
     );
-    let (num_permutation_z_polys, expression) = compose(&circuit_info);
+    let (num_permutation_z_polys, expression, _) = compose(&circuit_info);
     assert_eq!(num_permutation_z_polys, 1);
     expression
 }
@@ -190,6 +190,7 @@ pub fn rand_vanilla_plonk_assignment<F: PrimeField, R: Rotatable + From<usize>>(
 
     let permutation_polys = permutation_polys(num_vars, &[6, 7, 8], &permutations);
     let permutation_z_polys = permutation_z_polys::<_, R>(
+        3,
         1,
         &[6, 7, 8]
             .into_iter()
@@ -348,6 +349,7 @@ pub fn rand_vanilla_plonk_w_lookup_assignment<F: PrimeField + Hash, R: Rotatable
 
     let permutation_polys = permutation_polys(num_vars, &[10, 11, 12], &permutations);
     let permutation_z_polys = permutation_z_polys::<_, R>(
+        3,
         1,
         &[10, 11, 12]
             .into_iter()

--- a/plonkish_backend/src/backend/unihyperplonk.rs
+++ b/plonkish_backend/src/backend/unihyperplonk.rs
@@ -193,6 +193,7 @@ where
 
         let timer = start_timer(|| format!("permutation_z_polys-{}", pp.permutation_polys.len()));
         let permutation_z_polys = permutation_z_polys::<_, Lexical>(
+            pp.max_degree -1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,

--- a/plonkish_backend/src/backend/unihyperplonk.rs
+++ b/plonkish_backend/src/backend/unihyperplonk.rs
@@ -193,7 +193,7 @@ where
 
         let timer = start_timer(|| format!("permutation_z_polys-{}", pp.permutation_polys.len()));
         let permutation_z_polys = permutation_z_polys::<_, Lexical>(
-            pp.max_degree -1,
+            pp.max_degree - 1,
             pp.num_permutation_z_polys,
             &pp.permutation_polys,
             &polys,


### PR DESCRIPTION
This PR fixes an error in plonkish_backend/src/backend/hyperplonk/prover.rs that causes the verification of proofs to fail. 

The permutation argument is split into chunks because the number of columns might be greater than the max degree. In preprocessing, chunk_size is defined as max_degree -1. The number of chunks is set as the ceiling of the number of permutation polys divided by the chunk size. However, in proving the chunk_size is set as the ceiling of the number of permutation polys divided by the number of chunks. In some cases, this leads to the chunk_size being different in pre-processing to in proving, which causes a verification error for the resulting proof. For example say the pre-processing chunk size was 3, and the number of permutation polys is 4, then the number of chunks is 2. However in proving, the chunksize would be 4/2 = 2. 